### PR TITLE
feat: loadZip 支持加载用户本地 file

### DIFF
--- a/src/rime.js
+++ b/src/rime.js
@@ -1,13 +1,26 @@
-export async function loadZip(url) {
+export async function loadZip(fileOrUrl) {
   const [_, schema] = await Promise.all([
     fcitxReady,
-    fetch(url).then(res => {
-      if (!res.ok) {
-        throw new Error(`Get ${url} error`);
+    (async () => {
+      // Load schema from zip file or URL.
+      if (fileOrUrl instanceof File || fileOrUrl instanceof Blob) {
+        return new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onload = () => resolve(reader.result)
+          reader.onerror = reject
+          reader.readAsArrayBuffer(fileOrUrl)
+        })
+      } else if (typeof fileOrUrl === 'string') {
+        const response = await fetch(fileOrUrl)
+        if (!response.ok) {
+          throw new Error(`Get ${fileOrUrl} error`)
+        }
+        return response.arrayBuffer()
       }
-      return res.arrayBuffer()
-    })
+      throw new Error('Invalid input: expected File object or URL string')
+    })()
   ])
+
   // librime-qjs expects js in user dir.
   window.fcitx.unzip(schema, '/home/web_user/.local/share/fcitx5/rime')
   window.fcitx.enable()


### PR DESCRIPTION
 loadZip 支持加载用户本地 file，可以选择本地文件并创建为 file 文件。避免网站本地过大和跨域问题，同时保持对原本 URL 模式的兼容